### PR TITLE
Better types

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -64,16 +64,24 @@ function getTypeName(type: ts.TypeNode, context: Context): string {
 function getFunctionType(type: ts.FunctionTypeNode, context: Context): string {
   const returnType = getTypeName(type.type, context)
   const returnsVoid = returnType === 'void'
+  // skip this parameters - they don't actually exist
+  const parameters = [...type.parameters]
+  if (
+    parameters.length &&
+    parameters[0].name.getFullText(context.sourceFile) === 'this'
+  ) {
+    parameters.splice(0, 1)
+  }
   if (returnsVoid) {
     return (
       'Action<' +
-      type.parameters.map((p) => getTypeName(p.type!, context)).join(', ') +
+      parameters.map((p) => getTypeName(p.type!, context)).join(', ') +
       '>'
     )
   } else {
     return (
       'Func<' +
-      [...type.parameters.map((p) => p.type), type.type]
+      [...parameters.map((p) => p.type), type.type]
         .map((t) => getTypeName(t!, context))
         .join(', ') +
       '>'

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -44,6 +44,7 @@ function getTypeName(type: ts.TypeNode, context: Context): string {
     case ts.SyntaxKind.BooleanKeyword:
       return 'bool'
     case ts.SyntaxKind.AnyKeyword:
+    case ts.SyntaxKind.UnknownKeyword:
       return 'object'
     case ts.SyntaxKind.VoidKeyword:
       return 'void'

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -11,22 +11,85 @@ type Context = {
   elementName?: string
 }
 
-const reservedNames: Record<string, boolean> = {
-  as: true,
-  base: true,
-  checked: true,
-  default: true,
-  event: true,
-  float: true,
-  is: true,
-  object: true,
-  operator: true,
-  public: true,
-  switch: true,
-  static: true,
-  private: true,
-  this: true,
-}
+const reservedNames: Set<string> = new Set([
+  'abstract',
+  'as',
+  'base',
+  'bool',
+  'break',
+  'byte',
+  'case',
+  'catch',
+  'char',
+  'checked',
+  'class',
+  'const',
+  'continue',
+  'decimal',
+  'default',
+  'delegate',
+  'do',
+  'double',
+  'else',
+  'enum',
+  'event',
+  'explicit',
+  'extern',
+  'false',
+  'finally',
+  'fixed',
+  'float',
+  'for',
+  'foreach',
+  'goto',
+  'if',
+  'implicit',
+  'in',
+  'int',
+  'interface',
+  'internal',
+  'is',
+  'lock',
+  'long',
+  'namespace',
+  'new',
+  'null',
+  'object',
+  'operator',
+  'out',
+  'override',
+  'params',
+  'private',
+  'protected',
+  'public',
+  'readonly',
+  'ref',
+  'return',
+  'sbyte',
+  'sealed',
+  'short',
+  'sizeof',
+  'stackalloc',
+  'static',
+  'string',
+  'struct',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'uint',
+  'ulong',
+  'unchecked',
+  'unsafe',
+  'ushort',
+  'using',
+  'virtual',
+  'void',
+  'volatile',
+  'while',
+])
 
 function getTypeName(type: ts.TypeNode, context: Context): string {
   switch (type.kind) {
@@ -119,13 +182,7 @@ function getSafeName(
     ? member.text
     : (member.name as ts.StringLiteral).text
   // TODO Improve writing of reserved member names
-  return !reservedNames[name]
-    ? name
-    : ts.isIdentifier(member)
-    ? `${name}Parameter`
-    : ts.isPropertySignature(member)
-    ? `${name}Property`
-    : `${name}Method`
+  return !reservedNames.has(name) ? name : `@${name}`
 }
 
 function isReadonly(modifiers: ts.NodeArray<ts.Modifier> | undefined): boolean {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -148,7 +148,11 @@ function getParameterList(
     .join(', ')
 }
 
-function getTypeParameters(node: ts.InterfaceDeclaration): string {
+function getTypeParameters(
+  node: ts.NamedDeclaration & {
+    typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration>
+  },
+): string {
   if (!node.typeParameters?.length) {
     return ''
   }
@@ -183,11 +187,11 @@ function getMembers(node: ts.InterfaceDeclaration, context: Context): string[] {
       return `public new ${type} ${name} { ${accessors} }`
     }
     if (ts.isMethodSignature(member)) {
-      const ms = member as ts.MethodSignature
       const name = getSafeName(member)
+      const typeParameters = getTypeParameters(member)
       const type = getTypeName(member.type!, { ...context, elementName: name })
-      const parameters = getParameterList(ms.parameters, context)
-      return `public new ${type} ${name}(${parameters});`
+      const parameters = getParameterList(member.parameters, context)
+      return `public new ${type} ${name}${typeParameters}(${parameters});`
     }
     return `// TODO: Unsupported member: ${member.getText(context.sourceFile)}`
   })

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -48,11 +48,24 @@ function getTypeName(type: ts.TypeNode, context: Context): string {
   if (ts.isArrayTypeNode(type)) {
     return getTypeName(type.elementType, context) + '[]'
   }
+  if (ts.isFunctionTypeNode(type)) {
+    return getFunctionType(type, context)
+  }
 
   // TODO support more specific types, start with non-union types
   // TODO Support generics
   // TODO support for Nullable, CanBeUndefined (| null, | undefined)
   return `object /* ${type.getText(context.sourceFile)} */`
+}
+
+function getFunctionType(type: ts.FunctionTypeNode, context: Context): string {
+  const returnType = getTypeName(type.type, context);
+  const returnsVoid = returnType === 'void'
+  if (returnsVoid) {
+    return 'Action<' + type.parameters.map(p => getTypeName(p.type!, context)).join(', ') + '>'
+  } else {
+    return 'Func<' + [...type.parameters.map(p => p.type), type.type].map(t => getTypeName(t!, context)).join(', ') + '>'
+  }
 }
 
 function getSafeName(


### PR DESCRIPTION
Some improvements where types were previously missing:
- function types are now converted to either Action<...> or Func<...>, depending on whether they have a return value or not
- this types are converted to the containing type (e.g. Set.add)
- some instances of number now are int, based on some heuristics around the name of the member or parameter – this is still very limited; e.g. the various typed arrays are still mostly double
- unknown is treated the same as any